### PR TITLE
Mobile info text scrolling bug

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -38,6 +38,7 @@ function App() {
         navigationPosition={'left'}
         navigationTooltips={[]}
         showActiveTooltip
+        normalScrollElements={'.normalScroll'}
         anchors={['Explore', 'Communities', 'History', 'Attractions', 'Book']}
         render={({ state, fullpageApi }) => {
           return (
@@ -155,8 +156,8 @@ function App() {
                     </div>
                   </div>
                 </div>
-
               </ReactFullpage.Wrapper>
+
             </React.Fragment>
           );
         }}

--- a/src/assets/icons/info.svg
+++ b/src/assets/icons/info.svg
@@ -1,9 +1,33 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="61.8" height="61.8" viewBox="0 0 61.8 61.8">
-  <g id="Group_11" data-name="Group 11" transform="translate(-1786 -913.2)">
-    <text id="i" transform="translate(1810.395 958.145)" fill="#fff" font-size="48" font-family="SitkaHeading, Sitka Heading"><tspan x="0" y="0">i</tspan></text>
-    <g id="Ellipse_21" data-name="Ellipse 21" transform="translate(1786 913.2)" fill="none" stroke="#fff" stroke-width="2">
-      <circle cx="30.9" cy="30.9" r="30.9" stroke="none"/>
-      <circle cx="30.9" cy="30.9" r="29.9" fill="none"/>
+  <defs>
+    <style>
+      .cls-1 {
+        fill: #fff;
+        font-size: 48px;
+        font-family: Lora;
+      }
+
+      .cls-2, .cls-4 {
+        fill: none;
+      }
+
+      .cls-2 {
+        stroke: #fff;
+        stroke-width: 2px;
+      }
+
+      .cls-3 {
+        stroke: none;
+      }
+    </style>
+  </defs>
+  <g id="Group_13" data-name="Group 13" transform="translate(-1786 -913.2)">
+    <text id="i" class="cls-1" transform="translate(1810.395 958.145)"><tspan x="0" y="0">i</tspan></text>
+    <g id="Group_12" data-name="Group 12">
+      <g id="Ellipse_21" data-name="Ellipse 21" class="cls-2" transform="translate(1786 913.2)">
+        <circle class="cls-3" cx="30.9" cy="30.9" r="30.9"/>
+        <circle class="cls-4" cx="30.9" cy="30.9" r="29.9"/>
+      </g>
     </g>
   </g>
 </svg>

--- a/src/components/infoPanel.jsx
+++ b/src/components/infoPanel.jsx
@@ -6,17 +6,17 @@ export default function InfoPanel(props) {
 
     let infoClasses = "p-12 h-full md:h-screen w-full top-0 left-0 absolute wrapper"
 
-    if(props.open){
+    if (props.open) {
         infoClasses += ' wrapperShown'
     }
 
     return (
-        <div className={infoClasses} style={{background: props.solid?'#333333':'rgb(10,10,10,0.66)'}}>
+        <div className={`${infoClasses} normalScroll`} style={{ background: props.solid ? '#333333' : 'rgb(10,10,10,0.66)' }}>
             <div className="h-full flex flex-col mr-12 md:p-12 ">
-            <h1 className=" text-white md:max-w-xs font-display text-3xl md:text-4xl mb-2 md:mb-3 ">{props.title}</h1>
-            <div className="text-white md:max-w-xs h-full  overflow-auto ">
-                 {props.children} 
-            </div>
+                <h1 className=" text-white md:max-w-xs font-display text-3xl md:text-4xl mb-2 md:mb-3 ">{props.title}</h1>
+                <div className="text-white md:max-w-xs h-full  overflow-auto ">
+                    {props.children}
+                </div>
             </div>
         </div>
     )


### PR DESCRIPTION
Disabled fullpage js scrolling events for info text to allow scrolling on touch devices. Switched to a working font for info SVG icon.